### PR TITLE
Gpu pods fix

### DIFF
--- a/charts/dogkat/README.md
+++ b/charts/dogkat/README.md
@@ -42,6 +42,7 @@ The following table lists the configurable parameters of the chart and the defau
 | gpu.enabled | bool | `false` |  |
 | gpu.image.repo | string | `"nvidia/samples"` | The repo to be used |
 | gpu.image.tag | string | `"vectoradd-cuda11.2.1"` | The tag to be used |
+| gpu.nodeLabelSelectors."nvidia.com/gpu.present" | string | `"true"` |  |
 | gpu.numberOfGPUs | int | `1` |  |
 | gpu.resources | object | `{}` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/dogkat/templates/gpu-pod.yaml
+++ b/charts/dogkat/templates/gpu-pod.yaml
@@ -14,13 +14,14 @@ metadata:
     {{- include "e2e-testing.gpu.labels" . | nindent 4 }}
 spec:
   restartPolicy: OnFailure
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
   containers:
     - name: nvidia-vectoradd
       image: {{.Values.gpu.image.repo}}:{{.Values.gpu.image.tag}}
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: File
       imagePullPolicy: IfNotPresent
-
       {{- if .Values.gpu.resources }}
       resources:
         "nvidia.com/gpu": {{ .Values.gpu.numberOfGPUs }}

--- a/charts/dogkat/templates/gpu-pod.yaml
+++ b/charts/dogkat/templates/gpu-pod.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   restartPolicy: OnFailure
   nodeSelector:
-    nvidia.com/gpu.present: "true"
+    {{- toYaml .Values.gpu.nodeLabelSelectors| nindent 4 }}
   containers:
     - name: nvidia-vectoradd
       image: {{.Values.gpu.image.repo}}:{{.Values.gpu.image.tag}}

--- a/charts/dogkat/values.yaml
+++ b/charts/dogkat/values.yaml
@@ -45,6 +45,8 @@ gpu:
     # -- The tag to be used
     tag: vectoradd-cuda11.2.1
   resources: {}
+  nodeLabelSelectors:
+    nvidia.com/gpu.present: "true"
 
 ingress:
   enabled: false


### PR DESCRIPTION
Just adds a label selector for the GPU pod to prevent it hitting a node without a GPU, which evidently isn't restrained by the requesting of a GPU via resources. Go figure!