### PR TITLE
Operation cannot be fulfilled (attempted) fix

### DIFF
--- a/pkg/testsuite/autoscaling.go
+++ b/pkg/testsuite/autoscaling.go
@@ -76,11 +76,16 @@ func (c *ScalingTest) Run() error {
 	log.Printf("Running Test: %s\n", c.Test.Name)
 	log.Printf("Node count before Scale %v\n", c.StartingNodes)
 
-	// Increase the replicas
-	c.Deployment.Deployment.Spec.Replicas = helpers.IntPtr(c.TargetReplicas)
-
 	re := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		d, err := c.Deployment.Update(context.Background(), c.Deployment.Deployment, metav1.UpdateOptions{})
+		deploy, err := c.Deployment.Get()
+		if err != nil {
+			return err
+		}
+
+		// Increase the replicas
+		deploy.Spec.Replicas = helpers.IntPtr(c.TargetReplicas)
+
+		d, err := c.Deployment.Update(context.Background(), deploy, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We sporadically hit the following error when scaling the deployment
```
Error: Operation cannot be fulfilled on deployments.apps "nginx-e2e": the object has been modified; please apply your changes to the latest version and try again
```

This appears to be due t the fact we're updating the deployment in place rather than fetching it, setting the new replicas value and then updating it.

This attempts to prevent that error.