### PR TITLE
updated value used for namespace removal

### DIFF
--- a/pkg/cmd/delete/delete.go
+++ b/pkg/cmd/delete/delete.go
@@ -57,10 +57,10 @@ func NewDeleteCommand(cf *genericclioptions.ConfigFlags) *cobra.Command {
 				return err
 			}
 
-			if err = deleteNamespaceOnSuccess(client.KubeClient, *cf.Namespace); err != nil {
+			if err = deleteNamespaceOnSuccess(client.KubeClient, *configFlags.Namespace); err != nil {
 				return err
 			}
-			
+
 			return nil
 		},
 	}


### PR DESCRIPTION
The value used technically was the same due to the referencing of the original value, but for the sake of consistency, it's being updated here to use the same variable.